### PR TITLE
Remove usage of `SwingUtilities.invokeLater`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ## [Unreleased]
 ### Added
 
-## [0.8.0] - 2022-02-11
+## [0.8.0] - 2022-02-12
 ### Changed
 - Fix warning when upgrading plugin to PhpStorm 2021.3.2
 - Update build system to make upgrading plugin easier and improve QA
-- Remove deprecated API usage
+- Remove deprecated API usages
 
 ## [0.7.0] - 2021-08-09
 ### Added

--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
@@ -2,7 +2,10 @@ package com.daveme.chocolateCakePHP;
 
 import com.daveme.chocolateCakePHP.ui.FullyQualifiedNameInsertHandler;
 import com.daveme.chocolateCakePHP.ui.FullyQualifiedNameTextFieldCompletionProvider;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.options.SearchableConfigurable;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.textCompletion.TextFieldWithCompletion;
 import com.jetbrains.php.completion.PhpCompletionUtil;
@@ -140,14 +143,10 @@ class ConfigForm implements SearchableConfigurable {
 
     private void createUIComponents() {
         FullyQualifiedNameInsertHandler insertHandler = new FullyQualifiedNameInsertHandler();
-        try {
-            if (!SwingUtilities.isEventDispatchThread()) {
-                SwingUtilities.invokeAndWait(() -> setupHandler(insertHandler));
-            } else {
-                setupHandler(insertHandler);
-            }
-        } catch (InterruptedException | InvocationTargetException e) {
-            e.printStackTrace();
+        if (!SwingUtilities.isEventDispatchThread()) {
+            ApplicationManager.getApplication().invokeAndWait(() -> setupHandler(insertHandler), ModalityState.any());
+        } else {
+            setupHandler(insertHandler);
         }
     }
 


### PR DESCRIPTION
`SwingUtilities.invokeLater()` is not supported by IntelliJ.

 Replace with the corresponding supported API.

 See https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html#modality-and-invokelater