### PR TITLE
Downgrade Kotlin to version supported by 2021.2/2021.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
@@ -7,7 +6,8 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.6.20"
+    // Note: update based on IntelliJ version from https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
+    id("org.jetbrains.kotlin.jvm") version "1.5.10"
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij") version "1.5.2"
     // Gradle Changelog Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,21 +4,21 @@
 pluginGroup = com.daveme.chocolateCakePHP
 pluginName = chocolate-cakephp
 # SemVer format -> https://semver.org
-pluginVersion = 0.8.1
+pluginVersion = 0.8.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 213.6461.21
+pluginSinceBuild = 212.5712.51
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2021.3.3
+platformVersion = 2021.2.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 # populate from https://www.jetbrains.com/phpstorm/download/other.html
-platformPlugins = com.jetbrains.php:213.7172.28
+platformPlugins = com.jetbrains.php:212.5712.51
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
 
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="213.6461.21"/>
+    <idea-version since-build="212.5712.51"/>
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.daveme.chocolateCakePHP.Settings" />
 


### PR DESCRIPTION
Last update only supports 2021.3.*. There was one bugfix, and in addition the version of Kotlin we're using for 2021.3 is newer than the one that's actually installed.

So, downgrade the version of Kotlin to the one supported by 2021.2/2021.3, and support back to 2021.4