### PR TITLE
Split controller completion contributor v0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [0.8.2] - 2022-05-29
+### Changed
+- Fix problem with completion of Cake 2 models and components from controllers
+
 ## [0.8.1] - 2022-04-26
 ### Changed
 - Update for PhpStorm 2022.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.daveme.chocolateCakePHP
 pluginName = chocolate-cakephp
 # SemVer format -> https://semver.org
-pluginVersion = 0.8.1
+pluginVersion = 0.8.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/classes.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/classes.kt
@@ -45,7 +45,6 @@ fun PhpIndex.getAllModelSubclasses(settings: Settings): Collection<PhpClass> {
     if (settings.cake2Enabled) {
         result += getAllSubclasses(MODEL_CAKE2_PARENT_CLASS)
     }
-//    val cake3Subclasses = phpIndex.getAllSubclasses(MODEL_CAKE3_PARENT_CLASS)
     return result
 }
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
@@ -42,7 +42,9 @@ class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
             val fieldReference = parent as FieldReference
             val settings =
                 Settings.getInstance(psiElement.project)
-            if (!settings.enabled) {
+            if (!settings.enabled ||
+                !settings.cake2Enabled
+            ) {
                 return
             }
 
@@ -85,10 +87,6 @@ class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
             completionResultSet: CompletionResultSet,
             fieldReferenceChild: FieldReference,
         ) {
-            // Only Cake2 models support nested lookup.
-            if (!settings.cake2Enabled) {
-                return
-            }
             val phpIndex = PhpIndex.getInstance(psiElement.project)
             val fieldName = fieldReferenceChild.name
             val isUppercase = fieldName?.startsWithUppercaseCharacter() ?: false

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
@@ -42,9 +42,7 @@ class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
             val fieldReference = parent as FieldReference
             val settings =
                 Settings.getInstance(psiElement.project)
-            if (!settings.enabled ||
-                !settings.cake2Enabled
-            ) {
+            if (!settings.cake2Enabled) {
                 return
             }
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
@@ -1,0 +1,118 @@
+package com.daveme.chocolateCakePHP.controller
+
+import com.daveme.chocolateCakePHP.*
+import com.intellij.codeInsight.completion.*
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import com.jetbrains.php.PhpIndex
+import com.jetbrains.php.lang.psi.elements.FieldReference
+import com.jetbrains.php.lang.psi.elements.Variable
+
+class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
+
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement().withParent(FieldReference::class.java),
+            ControllerCompletionProvider()
+        )
+        extend(
+            CompletionType.SMART,
+            PlatformPatterns.psiElement().withParent(FieldReference::class.java),
+            ControllerCompletionProvider()
+        )
+    }
+
+    private class ControllerCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+        override fun addCompletions(
+            completionParameters: CompletionParameters,
+            processingContext: ProcessingContext,
+            completionResultSet: CompletionResultSet
+        ) {
+            val psiElement = completionParameters.position
+            var parent = psiElement.parent ?: return
+            if (parent !is FieldReference) {
+                parent = findSiblingFieldReference(
+                    psiElement
+                ) ?: return
+            }
+
+            val fieldReference = parent as FieldReference
+            val settings =
+                Settings.getInstance(psiElement.project)
+            if (!settings.enabled) {
+                return
+            }
+
+            val childElement = fieldReference.firstChild
+            if (childElement is FieldReference) {
+                return nestedLookup(settings, psiElement, completionResultSet, childElement)
+            } else {
+                return directLookup(settings, psiElement, completionResultSet, fieldReference)
+            }
+        }
+
+        private fun directLookup(
+            settings: Settings,
+            psiElement: PsiElement,
+            completionResultSet: CompletionResultSet,
+            fieldReference: FieldReference,
+        ) {
+            val classReference = fieldReference.classReference ?: return
+            if (!classReference.type.isComplete || classReference !is Variable) {
+                return
+            }
+
+            val controllerClassNames = classReference.type.types.filter { it.isControllerClass() }
+            if (controllerClassNames.isNotEmpty()) {
+                val phpIndex = PhpIndex.getInstance(psiElement.project)
+                val containingClasses = phpIndex.getAllAncestorTypesFromFQNs(controllerClassNames)
+
+                val modelSubclasses = phpIndex.getAllModelSubclasses(settings)
+                completionResultSet.completeFromClasses(
+                    modelSubclasses,
+                    containingClasses = containingClasses
+                )
+            }
+
+        }
+
+        private fun nestedLookup(
+            settings: Settings,
+            psiElement: PsiElement,
+            completionResultSet: CompletionResultSet,
+            fieldReferenceChild: FieldReference,
+        ) {
+            // Only Cake2 models support nested lookup.
+            if (!settings.cake2Enabled) {
+                return
+            }
+            val phpIndex = PhpIndex.getInstance(psiElement.project)
+            val fieldName = fieldReferenceChild.name
+            val isUppercase = fieldName?.startsWithUppercaseCharacter() ?: false
+            if (!isUppercase) {
+                return
+            }
+
+            // Check if "child" (preceeding $this->FieldReference) is in the list of model subclasses
+            val modelClasses = phpIndex.getAllModelSubclasses(settings)
+            val fqn = "\\" + fieldName
+            if (!modelClasses.any { modelClass -> modelClass.fqn == fqn }) {
+                return
+            }
+            completionResultSet.completeFromClasses(modelClasses)
+        }
+
+    }
+
+    companion object {
+
+        private fun findSiblingFieldReference(element: PsiElement): PsiElement? {
+            val prevSibling = element.prevSibling ?: return null
+            return prevSibling.children.find { it is FieldReference }
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,8 @@
                              id="chocolatecakephp.PluginForm"
                              instance="com.daveme.chocolateCakePHP.PluginForm" />
 
-        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerCompletionContributor" />
+        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerCakeTwoModelCompletionContributor" />
+        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerComponentCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.view.ViewHelperInViewCompletionContributor" />
 
         <gotoDeclarationHandler implementation="com.daveme.chocolateCakePHP.view.ElementGotoDeclarationHandler" />


### PR DESCRIPTION
The controller completion contributor seems to be failing due to a timing issue due to timing out during load all the models and components in a real CakePHP 2 project in newer versions of PhpStorm.

Splitting up the model and component completion methods into two separate contributors doesn't hit that issue.