### PR TITLE
Handle isComplete method returning false

### DIFF
--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
@@ -5,7 +5,6 @@ import com.daveme.chocolateCakePHP.ui.FullyQualifiedNameTextFieldCompletionProvi
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.options.SearchableConfigurable;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.textCompletion.TextFieldWithCompletion;
 import com.jetbrains.php.completion.PhpCompletionUtil;

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerFieldTypeProvider.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerFieldTypeProvider.kt
@@ -25,19 +25,14 @@ class ControllerFieldTypeProvider : PhpTypeProvider4 {
             return null
         }
         val classReference = psiElement.classReference ?: return null
-        val referenceType = classReference.type
         val fieldReferenceName = psiElement.name ?: return null
-
-        // don't add types for nested types ($this->FooBar->FooBar) on cake 3+:
-        if (psiElement.firstChild is FieldReference && !settings.cake2Enabled) {
-            return null
-        }
 
         if (!fieldReferenceName.startsWithUppercaseCharacter()) {
             return null
         }
 
-        if (!referenceType.isComplete) {
+        // don't add types for nested types ($this->FooBar->FooBar) on cake 3+:
+        if (psiElement.firstChild is FieldReference) {
             if (settings.cake2Enabled) {
                 return cakeTwoNestedModelCompletion(psiElement)
             } else {
@@ -45,6 +40,7 @@ class ControllerFieldTypeProvider : PhpTypeProvider4 {
             }
         }
 
+        val referenceType = classReference.type.filterUnknown()
         for (type in referenceType.types) {
             if (type.isControllerClass()) {
                 return componentOrModelTypeFromFieldName(settings, fieldReferenceName)

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/view/ViewHelperInViewCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/view/ViewHelperInViewCompletionContributor.kt
@@ -3,6 +3,7 @@ package com.daveme.chocolateCakePHP.view
 import com.daveme.chocolateCakePHP.*
 import com.intellij.codeInsight.completion.*
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 import com.jetbrains.php.PhpIndex
 import com.jetbrains.php.lang.psi.elements.FieldReference
@@ -35,7 +36,10 @@ class ViewHelperInViewCompletionContributor : CompletionContributor() {
                 return
             }
 
-            val parent = (psiElement.parent ?: return) as? FieldReference ?: return
+            val parent = PsiTreeUtil.getParentOfType(
+                completionParameters.position,
+                FieldReference::class.java
+            ) ?: return
             val classReference = parent.classReference ?: return
             if (!classReference.textMatches("\$this")) {
                 return

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/view/ViewHelperInViewHelperTypeProvider.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/view/ViewHelperInViewHelperTypeProvider.kt
@@ -28,15 +28,13 @@ class ViewHelperInViewHelperTypeProvider : PhpTypeProvider4 {
         }
         val classReference = psiElement.classReference ?: return null
         val referenceType = classReference.type
-        if (!referenceType.isComplete) {
-            return null
-        }
+        val knownType = referenceType.filterUnknown()
 
         val fieldReferenceName = psiElement.name ?: return null
         if (!fieldReferenceName.startsWithUppercaseCharacter()) {
             return null
         }
-        for (type in referenceType.types) {
+        for (type in knownType.types) {
             if (type.contains("Helper")) {
                 return viewHelperTypeFromFieldName(settings, fieldReferenceName)
             }


### PR DESCRIPTION
The `isComplete()` method on PhpType is returning false on PhpStorm 2023.1 because it has incomplete types in addition to complete ones, and this causes the completion to fail sometimes.

Instead of checking `isComplete()`, use `filterUnknown()`.