### PR TITLE
Remove non working autocomplete for entry form

### DIFF
--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.form
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.form
@@ -24,7 +24,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <component id="12925" class="javax.swing.JLabel">
+              <component id="12925" class="javax.swing.JLabel" binding="cakeThreePlusTitle">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -200,7 +200,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <component id="e6a8d" class="javax.swing.JLabel">
+              <component id="e6a8d" class="javax.swing.JLabel" binding="cakeTwoTitle">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>

--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.form
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.form
@@ -30,7 +30,7 @@
                 </constraints>
                 <properties>
                   <font style="1"/>
-                  <text value="CakePHP 3 and CakePHP 4"/>
+                  <text value="CakePHP 3+"/>
                 </properties>
               </component>
               <component id="9dbcf" class="javax.swing.JCheckBox" binding="enableCake3SupportCheckBox" default-binding="true">
@@ -38,7 +38,7 @@
                   <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Enable CakePHP 3 / CakePHP 4 Support"/>
+                  <text value="Enable CakePHP 3+ Support"/>
                 </properties>
               </component>
               <component id="a650c" class="javax.swing.JSeparator">
@@ -159,7 +159,7 @@
                   <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="This is the extension used for view files. By default this is &quot;ctp&quot;. NOTE: this is only for CakePHP 3."/>
+                  <text value="&lt;html&gt;This is the extension used for view files. By default this is &lt;b&gt;ctp&lt;/b&gt;.&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt; this is only for CakePHP 3. For CakePHP 4+, &lt;b&gt;php&lt;/b&gt; extension is used.&lt;/html&gt;"/>
                 </properties>
               </component>
               <vspacer id="4cda0">

--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
@@ -136,6 +136,16 @@ class ConfigForm implements SearchableConfigurable {
 
     public void apply() {
         Settings settings = Settings.getInstance(project);
+
+        // Ensure namespace starts with backslash:
+        String namespace = appNamespaceTextField.getText();
+        if (settings.getCake3Enabled() &&
+                !namespace.isEmpty() &&
+                !namespace.startsWith("\\")) {
+            String newNamespace = "\\" + namespace;
+            appNamespaceTextField.setText(newNamespace);
+        }
+
         copySettingsFromUI(settings);
     }
 
@@ -146,6 +156,7 @@ class ConfigForm implements SearchableConfigurable {
         } else {
             setupHandler(insertHandler);
         }
+
     }
 
     private void setupHandler(FullyQualifiedNameInsertHandler insertHandler) {

--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
@@ -32,7 +32,9 @@ class ConfigForm implements SearchableConfigurable {
     private JButton appDirectoryDefaultButton;
     private JPanel cake3Panel;
     private JPanel cake2Panel;
-     
+    private JLabel cakeThreePlusTitle;
+    private JLabel cakeTwoTitle;
+
     public ConfigForm(Project project) {
         this.project = project;
     }

--- a/src/main/java/com/daveme/chocolateCakePHP/DataViews.form
+++ b/src/main/java/com/daveme/chocolateCakePHP/DataViews.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.daveme.chocolateCakePHP.ViewFileExtensionsForm">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.daveme.chocolateCakePHP.DataViewsForm">
   <grid id="27dc6" binding="topPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>

--- a/src/main/java/com/daveme/chocolateCakePHP/DataViews.form
+++ b/src/main/java/com/daveme/chocolateCakePHP/DataViews.form
@@ -30,7 +30,7 @@
             </constraints>
             <properties>
               <font style="1"/>
-              <text value="CakePHP View File Extensions"/>
+              <text value="CakePHP Data Views"/>
             </properties>
           </component>
           <component id="a487f" class="javax.swing.JSeparator">
@@ -59,7 +59,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="&lt;html&gt;Add any custom view file extensions you want to check for below.&lt;br&gt;This will be checked when navigating from a controller to a view file corresponding to an action.&lt;/html&gt;"/>
+              <text value="&lt;html&gt;Add any custom data view file extensions you want to check for below.&lt;br&gt;This will be checked when navigating from a controller to a view file corresponding to an action.&lt;/html&gt;"/>
             </properties>
           </component>
           <hspacer id="6209c">

--- a/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
@@ -45,7 +45,6 @@ public class DataViewsForm implements SearchableConfigurable {
     public JComponent createComponent() {
         Settings settings = Settings.getInstance(project);
         viewFileTableModel = ViewFileTableModel.fromSettings(settings);
-        final Settings defaults = Settings.getDefaults();
 
         this.tableView = new TableView<>(viewFileTableModel);
         ToolbarDecorator decorator = ToolbarDecorator.createDecorator(this.tableView, new ElementProducer<>() {
@@ -68,9 +67,7 @@ public class DataViewsForm implements SearchableConfigurable {
                     EDIT_ENTRY_LABEL,
                     project,
                     selected);
-            dialog.addTextFieldListener(fieldText -> {
-                viewFileTableModel.setValueAt(fieldText, selectedRow, 0);
-            });
+            dialog.addTextFieldListener(fieldText -> viewFileTableModel.setValueAt(fieldText, selectedRow, 0));
             dialog.setVisible(true);
         });
 
@@ -81,15 +78,11 @@ public class DataViewsForm implements SearchableConfigurable {
                     project,
                     ""
             );
-            dialog.addTextFieldListener(fieldText -> {
-                viewFileTableModel.addRow(fieldText);
-            });
+            dialog.addTextFieldListener(fieldText -> viewFileTableModel.addRow(fieldText));
             dialog.setVisible(true);
         });
 
-        decorator.setRemoveAction(action -> {
-            viewFileTableModel.removeRow(tableView.getSelectedRow());
-        });
+        decorator.setRemoveAction(action -> viewFileTableModel.removeRow(tableView.getSelectedRow()));
 
         decorator.disableUpAction();
         decorator.disableDownAction();
@@ -114,7 +107,7 @@ public class DataViewsForm implements SearchableConfigurable {
     }
 
     @Override
-    public void apply() throws ConfigurationException {
+    public void apply() {
         Settings settings = Settings.getInstance(project);
         copySettingsFromUI(settings);
     }

--- a/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.*;
 
-public class ViewFileExtensionsForm implements SearchableConfigurable {
+public class DataViewsForm implements SearchableConfigurable {
 
     private TableView<String> tableView;
     private final Project project;
@@ -22,17 +22,17 @@ public class ViewFileExtensionsForm implements SearchableConfigurable {
     private JPanel headlinePanelForPlugins;
     private JLabel viewFilesLabel;
 
-    private static final String EDIT_ENTRY_TITLE = "Edit View File Extension";
-    private static final String EDIT_ENTRY_LABEL = "View file extension";
+    private static final String EDIT_ENTRY_TITLE = "Data View Extension";
+    private static final String EDIT_ENTRY_LABEL = "Data view extension";
 
-    public ViewFileExtensionsForm(Project project) {
+    public DataViewsForm(Project project) {
         this.project = project;
     }
 
     @NotNull
     @Override
     public String getId() {
-        return "com.daveme.chocolateCakePHP.ViewFileExtensionsForm";
+        return "com.daveme.chocolateCakePHP.DataViewForm";
     }
 
     @Override
@@ -109,7 +109,7 @@ public class ViewFileExtensionsForm implements SearchableConfigurable {
 
     private void copySettingsFromUI(@NotNull Settings settings) {
         SettingsState state = settings.getState();
-        state.setViewFileExtensions(viewFileTableModel.getViewFiles());
+        state.setDataViewExtensions(viewFileTableModel.getViewFiles());
         settings.loadState(state);
     }
 

--- a/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/DataViewsForm.java
@@ -37,7 +37,7 @@ public class DataViewsForm implements SearchableConfigurable {
 
     @Override
     public String getDisplayName() {
-        return "CakePHP View File Extensions";
+        return "CakePHP Data Views";
     }
 
     @Nullable

--- a/src/main/java/com/daveme/chocolateCakePHP/EditEntryDialog.form
+++ b/src/main/java/com/daveme/chocolateCakePHP/EditEntryDialog.form
@@ -65,9 +65,9 @@
               <text value="FieldLabel"/>
             </properties>
           </component>
-          <component id="c0242" class="com.intellij.util.textCompletion.TextFieldWithCompletion" binding="fieldValueTextField" custom-create="true">
+          <component id="db5aa" class="javax.swing.JTextField" binding="fieldValueTextField">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="0" indent="0" use-parent-layout="false">
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>

--- a/src/main/java/com/daveme/chocolateCakePHP/EditEntryDialog.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/EditEntryDialog.java
@@ -1,11 +1,7 @@
 package com.daveme.chocolateCakePHP;
 
-import com.daveme.chocolateCakePHP.ui.FullyQualifiedNameInsertHandler;
-import com.daveme.chocolateCakePHP.ui.FullyQualifiedNameTextFieldCompletionProvider;
 import com.daveme.chocolateCakePHP.ui.TextFieldListener;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.textCompletion.TextFieldWithCompletion;
-import com.jetbrains.php.completion.PhpCompletionUtil;
 
 import javax.swing.*;
 import java.awt.event.*;
@@ -14,8 +10,8 @@ public class EditEntryDialog extends JDialog {
     private JPanel contentPane;
     private JButton buttonOK;
     private JButton buttonCancel;
-    private TextFieldWithCompletion fieldValueTextField;
     private JLabel fieldLabel;
+    private JTextField fieldValueTextField;
 
     final private Project project;
 
@@ -65,18 +61,6 @@ public class EditEntryDialog extends JDialog {
     }
 
     private void createUIComponents() {
-        FullyQualifiedNameInsertHandler insertHandler = new FullyQualifiedNameInsertHandler();
-        PhpCompletionUtil.PhpFullyQualifiedNameTextFieldCompletionProvider completionProvider =
-                new FullyQualifiedNameTextFieldCompletionProvider(project, insertHandler);
-        fieldValueTextField = new TextFieldWithCompletion(
-                project,
-                completionProvider,
-                "",
-                true,
-                true,
-                false,
-                false
-        );
     }
 
     public void addTextFieldListener(TextFieldListener listener) {

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
@@ -14,7 +14,7 @@ data class SettingsState(
     var cake2Enabled: Boolean = true,
     var cake3Enabled: Boolean = true,
     var pluginNamespaces: List<String> = arrayListOf("\\DebugKit"),
-    var viewFileExtensions: List<String> = arrayListOf("json", "xml", "rss")
+    var dataViewExtensions: List<String> = arrayListOf("json", "xml", "rss")
 )
 
 @Service
@@ -40,9 +40,9 @@ class Settings : PersistentStateComponent<SettingsState> {
             return pluginEntryListFromNamespaceList(state.pluginNamespaces)
         }
 
-    val viewFileExtensions: List<String>
+    val dataViewExtensions: List<String>
         get() {
-            return state.viewFileExtensions
+            return state.dataViewExtensions
         }
 
     val enabled: Boolean

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
@@ -14,7 +14,7 @@ data class SettingsState(
     var cake2Enabled: Boolean = true,
     var cake3Enabled: Boolean = true,
     var pluginNamespaces: List<String> = arrayListOf("\\DebugKit"),
-    var dataViewExtensions: List<String> = arrayListOf("json", "xml", "rss")
+    var dataViewExtensions: List<String> = arrayListOf("json", "xml")
 )
 
 @Service

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerMethodLineMarker.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerMethodLineMarker.kt
@@ -95,7 +95,7 @@ class ControllerMethodLineMarker : LineMarkerProvider {
         val pluginOrAppDir = topSourceDirectoryFromFile(settings, relatedLookupInfo.file)
             ?: return null
 
-        val fileExtensions = relatedLookupInfo.settings.viewFileExtensions
+        val fileExtensions = relatedLookupInfo.settings.dataViewExtensions
 
         // Create one file for each of the file extensions that match the naming convention:
         val files = actionNames.map { controllerAction ->

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerMethodLineMarker.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerMethodLineMarker.kt
@@ -4,9 +4,7 @@ import com.daveme.chocolateCakePHP.*
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.psi.elements.Method
 import com.jetbrains.php.lang.psi.elements.MethodReference
@@ -14,15 +12,7 @@ import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
 import com.jetbrains.php.lang.psi.elements.Variable
 
 
-data class RelatedLookupInfo(
-    val project: Project,
-    val settings: Settings,
-    val controllerName: String,
-    val file: PsiFile,
-)
-
 class ControllerMethodLineMarker : LineMarkerProvider {
-
 
     override fun getLineMarkerInfo(psiElement: PsiElement): LineMarkerInfo<*>? = null
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/RelatedLookupInfo.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/RelatedLookupInfo.kt
@@ -1,0 +1,12 @@
+package com.daveme.chocolateCakePHP.controller
+
+import com.daveme.chocolateCakePHP.Settings
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+data class RelatedLookupInfo(
+    val project: Project,
+    val settings: Settings,
+    val controllerName: String,
+    val file: PsiFile,
+)

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/ui/ViewFileColumn.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/ui/ViewFileColumn.kt
@@ -1,6 +1,5 @@
 package com.daveme.chocolateCakePHP.ui
 
-import com.daveme.chocolateCakePHP.PluginEntry
 import com.intellij.util.ui.ColumnInfo
 
 class ViewFileColumn(name: String) : ColumnInfo<String, String>(name) {

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/ui/ViewFileTableModel.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/ui/ViewFileTableModel.kt
@@ -1,6 +1,5 @@
 package com.daveme.chocolateCakePHP.ui
 
-import com.daveme.chocolateCakePHP.PluginEntry
 import com.daveme.chocolateCakePHP.Settings
 import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.ListTableModel
@@ -73,12 +72,12 @@ class ViewFileTableModel private constructor(
     companion object {
         private val myColumns =
             arrayOf<ColumnInfo<String, String>>(
-                ViewFileColumn("File Extension")
+                ViewFileColumn("Data View Extension")
             )
 
         @JvmStatic
         fun fromSettings(settings: Settings): ViewFileTableModel {
-            return ViewFileTableModel(settings.viewFileExtensions.toMutableList(), myColumns)
+            return ViewFileTableModel(settings.dataViewExtensions.toMutableList(), myColumns)
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,7 +36,7 @@
                              instance="com.daveme.chocolateCakePHP.PluginForm" />
 
         <projectConfigurable parentId="chocolatecakephp.ConfigForm"
-                             displayName="View File Extensions"
+                             displayName="Data Views"
                              id="chocolatecakephp.ui.ViewFileExtensionsForm"
                              instance="com.daveme.chocolateCakePHP.DataViewsForm" />
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,7 +38,7 @@
         <projectConfigurable parentId="chocolatecakephp.ConfigForm"
                              displayName="View File Extensions"
                              id="chocolatecakephp.ui.ViewFileExtensionsForm"
-                             instance="com.daveme.chocolateCakePHP.ViewFileExtensionsForm" />
+                             instance="com.daveme.chocolateCakePHP.DataViewsForm" />
 
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerCakeTwoModelCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerComponentCompletionContributor" />


### PR DESCRIPTION
- Remove EditPluginEntry in favor of EditEntry because the autocomplete doesn't work anyway
- Rename view file extensions to data views
- Make sure app namespace starts with a backslash by checking when `apply()` is called on the settings form
- Fix width of the main settings form and some other miscellaneous style changes on UI