### PR TITLE
Change ViewFilePathInfo to have dir/filename

### DIFF
--- a/src/main/kotlin/com/daveme/chocolateCakePHP/cake/CakePaths.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/cake/CakePaths.kt
@@ -239,23 +239,18 @@ fun elementPathToVirtualFile(
 
 data class ViewFilePathInfo(
     val templateDirPath: String, // relative to project root.
-    val controllerName: String,
     val viewFilename: String,
-) {
-    val templateAndControllerPath: String
-        get() = "${templateDirPath}/${controllerName}"
-}
+)
 
 fun viewFilePathInfoFromPath(viewFilePath: String): ViewFilePathInfo? {
     val pathPartsList = viewFilePath.split("/".toRegex())
-    if (pathPartsList.size < 3) {
+    if (pathPartsList.size < 2) {
         return null
     }
-    val lastElements = pathPartsList.takeLast(2)
-    val templateDir = pathPartsList.dropLast(2)
+    val lastElements = pathPartsList.takeLast(1)
+    val templateDir = pathPartsList.dropLast(1)
     return ViewFilePathInfo(
         templateDirPath = templateDir.joinToString("/"),
-        controllerName = lastElements.first(),
-        viewFilename = lastElements.get(1)
+        viewFilename = lastElements.first()
     )
 }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
@@ -52,25 +52,28 @@ class CreateViewFileAction(
             object : Runnable {
                 override fun run() {
 
-
                     val template = FileTemplateManager.getInstance(project)
                         .getInternalTemplate("CakePHP View File.php")
                     val text = template.getText()
-
 
                     val viewFilePathInfo = viewFilePathInfoFromPath(filePath) ?: return
                     val parentDir = viewFilePathInfo.templateDirPath
                     val filename = viewFilePathInfo.viewFilename
                     val baseDirPath = baseDir.path
                     if (!createDirectoriesIfMissing("${baseDirPath}/${parentDir}")) {
+                        Messages.showErrorDialog("Failed to create directories", "Create View File")
                         return
                     }
                     val parentDirVirtualFile = baseDir.findFileByRelativePath(parentDir) ?: return
                     if (!parentDirVirtualFile.isDirectory) {
+                        Messages.showErrorDialog("Failed to create directories", "Create View File")
                         return
                     }
                     val parentDirPsiFile = PsiManager.getInstance(project).findDirectory(parentDirVirtualFile)
-                        ?: return
+                    if (parentDirPsiFile == null) {
+                        Messages.showErrorDialog("Failed to create directories", "Create View File")
+                        return
+                    }
 
                     val psiFile = PsiFileFactory.getInstance(project)
                         .createFileFromText(

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
@@ -7,6 +7,7 @@ import com.intellij.ide.fileTemplates.FileTemplateManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.fileTypes.FileTypeManager
@@ -61,17 +62,17 @@ class CreateViewFileAction(
                     val filename = viewFilePathInfo.viewFilename
                     val baseDirPath = baseDir.path
                     if (!createDirectoriesIfMissing("${baseDirPath}/${parentDir}")) {
-                        Messages.showErrorDialog("Failed to create directories", "Create View File")
+                        showError("Failed to create directories")
                         return
                     }
                     val parentDirVirtualFile = baseDir.findFileByRelativePath(parentDir) ?: return
                     if (!parentDirVirtualFile.isDirectory) {
-                        Messages.showErrorDialog("Failed to create directories", "Create View File")
+                        showError("Failed to create directories")
                         return
                     }
                     val parentDirPsiFile = PsiManager.getInstance(project).findDirectory(parentDirVirtualFile)
                     if (parentDirPsiFile == null) {
-                        Messages.showErrorDialog("Failed to create directories", "Create View File")
+                        showError("Failed to create directories")
                         return
                     }
 
@@ -88,7 +89,14 @@ class CreateViewFileAction(
                         OpenFileDescriptor(project, result.virtualFile).navigate(true)
                     }
                 }
+
+                fun showError(error: String) {
+                    ApplicationManager.getApplication().invokeLater {
+                        Messages.showErrorDialog(error, "Create View File")
+                    }
+                }
             }
+
         )
     }
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
@@ -59,7 +59,7 @@ class CreateViewFileAction(
 
 
                     val viewFilePathInfo = viewFilePathInfoFromPath(filePath) ?: return
-                    val parentDir = viewFilePathInfo.templateAndControllerPath
+                    val parentDir = viewFilePathInfo.templateDirPath
                     val filename = viewFilePathInfo.viewFilename
                     val baseDirPath = baseDir.path
                     if (!createDirectoriesIfMissing("${baseDirPath}/${parentDir}")) {

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/CreateViewFileAction.kt
@@ -67,12 +67,12 @@ class CreateViewFileAction(
                     }
                     val parentDirVirtualFile = baseDir.findFileByRelativePath(parentDir) ?: return
                     if (!parentDirVirtualFile.isDirectory) {
-                        showError("Failed to create directories")
+                        showError("Failed to find directory")
                         return
                     }
                     val parentDirPsiFile = PsiManager.getInstance(project).findDirectory(parentDirVirtualFile)
                     if (parentDirPsiFile == null) {
-                        showError("Failed to create directories")
+                        showError("Failed to find directory")
                         return
                     }
 


### PR DESCRIPTION
The user might add another directory, so change
the result so it only has the filename and dir in separate properties.