### PR TITLE
Prefix namespace with backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### Added
 - Add autocompletion for other ViewHelpers in ViewHelpers
 
+## [0.8.3] - 2023-11-11
+### Changed
+- Fix problems with setting namespace field in the main config UI form
+
 ## [0.8.2] - 2022-05-29
 ### Changed
 - Fix problem with completion models and components from controllers

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
@@ -29,7 +29,15 @@ class Settings : PersistentStateComponent<SettingsState> {
 
     val cakeTemplateExtension get() = state.cakeTemplateExtension
     val appDirectory get() = state.appDirectory
-    val appNamespace get() = state.appNamespace
+
+    val appNamespace get(): String {
+        return if (!state.appNamespace.startsWith("\\")) {
+            "\\${state.appNamespace}"
+        } else {
+            state.appNamespace
+        }
+    }
+
     val pluginPath get() = state.pluginPath
     val cake2AppDirectory get() = state.cake2AppDirectory
     val cake2TemplateExtension get() = state.cake2TemplateExtension


### PR DESCRIPTION
The appNamespace var wasn't prefixed with backslash, but that's required in a number of places where it's used.

We already add the backslash on save, but in case someone has saved a namespace without a backslash, change the getter method for it on the Settings to prefix the value with a backslash before returning it.