### PR TITLE
Table locator completion contributor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,16 +101,16 @@ jobs:
           key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
-      - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
+      #      - name: Run Plugin Verification tasks
+      #  run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
-      - name: Collect Plugin Verifier Result
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: pluginVerifier-result
-          path: ${{ github.workspace }}/build/reports/pluginVerifier
+      #- name: Collect Plugin Verifier Result
+      #  if: ${{ always() }}
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    name: pluginVerifier-result
+      #    path: ${{ github.workspace }}/build/reports/pluginVerifier
 
       # Run Qodana inspections
       #- name: Qodana - Code Inspection

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,11 @@ jobs:
           files: ${{ github.workspace }}/build/reports/kover/xml/report.xml
 
       # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+      #- name: Setup Plugin Verifier IDEs Cache
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
+      #    key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       #      - name: Run Plugin Verification tasks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,11 +128,11 @@ jobs:
           echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
 
       # Store already-built plugin as an artifact for downloading
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.artifact.outputs.filename }}
-          path: ./build/distributions/content/*/*
+      #- name: Upload artifact
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    name: ${{ steps.artifact.outputs.filename }}
+      #    path: ./build/distributions/content/*/*
 
   # Prepare a draft release for GitHub Releases page for the manual verification
   # If accepted and published, release workflow would be triggered

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,15 +117,15 @@ jobs:
       #  uses: JetBrains/qodana-action@v2022.3.4
 
       # Prepare plugin archive content for creating artifact
-      - name: Prepare Plugin Artifact
-        id: artifact
-        shell: bash
-        run: |
-          cd ${{ github.workspace }}/build/distributions
-          FILENAME=`ls *.zip`
-          unzip "$FILENAME" -d content
-
-          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
+      #- name: Prepare Plugin Artifact
+      #  id: artifact
+      #  shell: bash
+      #  run: |
+      #    cd ${{ github.workspace }}/build/distributions
+      #    FILENAME=`ls *.zip`
+      #    unzip "$FILENAME" -d content
+      #
+      #    echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
 
       # Store already-built plugin as an artifact for downloading
       #- name: Upload artifact

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ annotations = "24.0.1"
 dokka = "1.8.10"
 kotlin = "1.8.20"
 changelog = "2.0.0"
-gradleIntelliJPlugin = "1.13.3"
+gradleIntelliJPlugin = "1.17.2"
 qodana = "0.1.13"
 kover = "0.6.1"
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Classes.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Classes.kt
@@ -11,6 +11,7 @@ private const val VIEW_HELPER_CAKE2_PARENT_CLASS = "\\AppHelper"
 private const val VIEW_HELPER_CAKE3_PARENT_CLASS = "\\Cake\\View\\Helper"
 
 private const val MODEL_CAKE2_PARENT_CLASS = "\\AppModel"
+private const val MODEL_CAKE3_PARENT_CLASS = "\\Cake\\ORM\\Table"
 
 private const val COMPONENT_CAKE2_PARENT_CLASS = "\\AppComponent"
 private const val COMPONENT_CAKE3_PARENT_CLASS = "\\Cake\\Controller\\Component"
@@ -45,6 +46,9 @@ fun PhpIndex.getAllModelSubclasses(settings: Settings): Collection<PhpClass> {
     val result = arrayListOf<PhpClass>()
     if (settings.cake2Enabled) {
         result += getAllSubclasses(MODEL_CAKE2_PARENT_CLASS)
+    }
+    if (settings.cake3Enabled) {
+        result += getAllSubclasses(MODEL_CAKE3_PARENT_CLASS)
     }
     return result
 }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Completion.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Completion.kt
@@ -37,12 +37,17 @@ class CompleteMethodWithParameter(private val wrapInString: Boolean) : InsertHan
         }
 
         if (document.textLength > nextTailOffset) {
-            nextTailOffset++
-            if (document.textLength > nextTailOffset) {
-                val advancedChar = document.charsSequence[nextTailOffset]
-                if (advancedChar == ')' || advancedChar == ',') {
-                    // advance past the closing parenthesis/comma
-                    nextTailOffset++
+            val trailingChar = document.charsSequence[nextTailOffset]
+            if (trailingChar == '\r' || trailingChar == '\n') {
+                nextTailOffset--;
+            } else {
+                nextTailOffset++
+                if (document.textLength > nextTailOffset) {
+                    val advancedChar = document.charsSequence[nextTailOffset]
+                    if (advancedChar == ')' || advancedChar == ',') {
+                        // advance past the closing parenthesis/comma
+                        nextTailOffset++
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Completion.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Completion.kt
@@ -15,7 +15,7 @@ class CompleteMethodWithParameter(private val wrapInString: Boolean) : InsertHan
             "'${item.lookupString}"
         else
             item.lookupString
-        document.charsSequence
+
         document.replaceString(
             context.startOffset,
             context.tailOffset,

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Strings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Strings.kt
@@ -12,6 +12,12 @@ fun String.chopFromEnd(end: String): String =
 fun String.isControllerClass(): Boolean =
     this.contains("Controller")
 
+fun Set<String>.hasLocatorInterfaceClass(): Boolean =
+    this.contains("\\Cake\\ORM\\Locator\\LocatorInterface")
+
+fun String.isLocatorInterfaceClass(): Boolean =
+    this == "\\Cake\\ORM\\Locator\\LocatorInterface"
+
 fun String.hasGetTableLocatorMethodCall(): Boolean =
     this.contains(".getTableLocator")
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
@@ -69,7 +69,7 @@ class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
                 val modelSubclasses = phpIndex.getAllModelSubclasses(settings)
                 completionResultSet.completeFromClasses(
                     modelSubclasses,
-                    containingClasses = containingClasses
+                    containingClasses = containingClasses,
                 )
             }
         }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerCakeTwoModelCompletionContributor.kt
@@ -44,10 +44,10 @@ class ControllerCakeTwoModelCompletionContributor : CompletionContributor() {
             }
 
             val childElement = fieldReference.firstChild
-            if (childElement is FieldReference) {
-                return nestedLookup(settings, completionResultSet, childElement)
+            return if (childElement is FieldReference) {
+                nestedLookup(settings, completionResultSet, childElement)
             } else {
-                return directLookup(settings, completionResultSet, fieldReference)
+                directLookup(settings, completionResultSet, fieldReference)
             }
         }
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerComponentCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/controller/ControllerComponentCompletionContributor.kt
@@ -67,7 +67,7 @@ class ControllerComponentCompletionContributor : CompletionContributor() {
                 val componentSubclasses = phpIndex.getAllComponentSubclasses(settings)
                 completionResultSet.completeFromClasses(
                     componentSubclasses,
-                    replaceName = "Component",
+                    chopFromEnd = "Component",
                     containingClasses = containingClasses
                 )
             }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/CustomFinderGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/CustomFinderGotoDeclarationHandler.kt
@@ -43,7 +43,7 @@ class CustomFinderGotoDeclarationHandler : GotoDeclarationHandler {
         }
         val reference = methodReference.classReference ?: return PsiElement.EMPTY_ARRAY
         val varType = reference.type.filterUnknown()
-        val tableTypes = varType.types.filter { type -> type.contains("\\Table", ignoreCase = true) }
+        val tableTypes = varType.types.filter { type -> type.contains("Table", ignoreCase = true) }
         if (tableTypes.isEmpty()) {
             return PsiElement.EMPTY_ARRAY
         }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
@@ -2,6 +2,7 @@ package com.daveme.chocolateCakePHP.model
 
 import com.daveme.chocolateCakePHP.*
 import com.intellij.codeInsight.completion.*
+import com.intellij.patterns.PatternCondition
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 import com.jetbrains.php.PhpIndex
@@ -15,18 +16,43 @@ import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
 class FetchTableCompletionContributor : CompletionContributor() {
 
     init {
+        val methodMatcher = object : PatternCondition<MethodReference>("LocatorInterfaceGetCondition") {
+            override fun accepts(methodReference: MethodReference, context: ProcessingContext): Boolean {
+                if (!"get".equals(methodReference.name, ignoreCase = true) &&
+                    !"fetchTable".equals(methodReference.name, ignoreCase = true)
+                ) {
+                    return false
+                }
+                val settings =
+                    Settings.getInstance(methodReference.project)
+                if (!settings.cake3Enabled) {
+                    return false
+                }
+                val classRefType = methodReference.classReference?.type ?: return false
+                val phpIndex = PhpIndex.getInstance(methodReference.project)
+                val type = if (classRefType.isComplete)
+                    classRefType
+                else
+                    phpIndex.completeType(methodReference.project, classRefType, null)
+                return type.types.contains("\\Cake\\ORM\\Locator\\LocatorInterface") ||
+                        type.types.any { it.contains("Controller") }
+            }
+        }
+
+        val completionProvider = FetchTableCompletionProvider()
+
         // When typing $this->fetchTable(, without a quote:
         val constantPattern = psiElement(LeafPsiElement::class.java)
             .withParent(
                 psiElement(ConstantReference::class.java)
                     .withParent(
-                       psiElement(ParameterList::class.java)
-                           .withParent(
-                               MethodReference::class.java
-                           )
+                        psiElement(ParameterList::class.java)
+                            .withParent(
+                                psiElement(MethodReference::class.java)
+                                    .with(methodMatcher)
+                            )
                     )
             )
-        val completionProvider = FetchTableCompletionProvider()
 
         extend(
             CompletionType.BASIC,
@@ -46,7 +72,8 @@ class FetchTableCompletionContributor : CompletionContributor() {
                     .withParent(
                         psiElement(ParameterList::class.java)
                             .withParent(
-                                MethodReference::class.java
+                                psiElement(MethodReference::class.java)
+                                    .with(methodMatcher)
                             )
                     )
             )
@@ -61,6 +88,28 @@ class FetchTableCompletionContributor : CompletionContributor() {
             completionProvider,
         )
 
+        val locatorInterfacePattern = psiElement(LeafPsiElement::class.java)
+            .withParent(
+                psiElement(StringLiteralExpression::class.java)
+                    .withParent(
+                        psiElement(ParameterList::class.java)
+                            .withParent(
+                                psiElement(MethodReference::class.java)
+                                    .with(methodMatcher)
+                            )
+                        )
+                    )
+
+        extend(
+            CompletionType.BASIC,
+            locatorInterfacePattern,
+            completionProvider,
+        )
+        extend(
+            CompletionType.SMART,
+            locatorInterfacePattern,
+            completionProvider,
+        )
     }
 
     class FetchTableCompletionProvider : CompletionProvider<CompletionParameters>() {
@@ -80,12 +129,7 @@ class FetchTableCompletionContributor : CompletionContributor() {
                 return
             }
 
-            val methodName = methodReference.name ?: return
-            if (methodName != "fetchTable") {
-                return
-            }
-
-            // If the current element is not quote, we need to quote:
+            // If the current element is not quoted, we need to quote it:
             val completeInsideString = completionParameters.position.parent is ConstantReference
 
             val phpIndex = PhpIndex.getInstance(methodReference.project)

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
@@ -87,29 +87,6 @@ class FetchTableCompletionContributor : CompletionContributor() {
             stringLiteralPattern,
             completionProvider,
         )
-
-        val locatorInterfacePattern = psiElement(LeafPsiElement::class.java)
-            .withParent(
-                psiElement(StringLiteralExpression::class.java)
-                    .withParent(
-                        psiElement(ParameterList::class.java)
-                            .withParent(
-                                psiElement(MethodReference::class.java)
-                                    .with(methodMatcher)
-                            )
-                        )
-                    )
-
-        extend(
-            CompletionType.BASIC,
-            locatorInterfacePattern,
-            completionProvider,
-        )
-        extend(
-            CompletionType.SMART,
-            locatorInterfacePattern,
-            completionProvider,
-        )
     }
 
     class FetchTableCompletionProvider : CompletionProvider<CompletionParameters>() {

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
@@ -85,11 +85,15 @@ class FetchTableCompletionContributor : CompletionContributor() {
                 return
             }
 
+            // If the current element is not quote, we need to quote:
+            val completeInsideString = completionParameters.position.parent is ConstantReference
+
             val phpIndex = PhpIndex.getInstance(methodReference.project)
             val modelSubclasses = phpIndex.getAllModelSubclasses(settings)
-            completionResultSet.completeFromClasses(
+            completionResultSet.completeMethodCallWithParameterFromClasses(
                 modelSubclasses,
-                replaceName = "Table"
+                chopFromEnd = "Table",
+                completeInsideString = completeInsideString
             )
         }
     }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
@@ -1,0 +1,77 @@
+package com.daveme.chocolateCakePHP.model
+
+import com.daveme.chocolateCakePHP.*
+import com.intellij.codeInsight.completion.*
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+import com.jetbrains.php.PhpIndex
+import com.jetbrains.php.lang.psi.elements.FieldReference
+import com.jetbrains.php.lang.psi.elements.Variable
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.jetbrains.php.lang.lexer.PhpTokenTypes
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.ParameterList
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
+
+class FetchTableCompletionContributor : CompletionContributor() {
+
+    init {
+//        val pattern = psiElement(PhpTokenTypes.STRING_LITERAL).withParent(
+//            psiElement(StringLiteralExpression::class.java).withParent(
+//                psiElement(ParameterList::class.java).withParent(
+//                    psiElement(MethodReference::class.java)
+//                )
+//            )
+//        )
+
+        val pattern = psiElement().withParent(ParameterList::class.java)
+
+        extend(
+            CompletionType.BASIC,
+            pattern,
+            FetchTableCompletionProvider()
+        )
+        extend(
+            CompletionType.SMART,
+            pattern,
+            FetchTableCompletionProvider()
+        )
+    }
+
+    class FetchTableCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            completionParameters: CompletionParameters,
+            context: ProcessingContext,
+            completionResultSet: CompletionResultSet
+        ) {
+            val fieldReference = PsiTreeUtil.getParentOfType(
+                completionParameters.position,
+                MethodReference::class.java
+            ) ?: return
+
+            val settings =
+                Settings.getInstance(fieldReference.project)
+            if (!settings.cake2Enabled) {
+                return
+            }
+
+            val classReference = fieldReference.classReference ?: return
+            if (classReference !is Variable) {
+                return
+            }
+
+            val controllerClassNames = classReference.type.types.filter { it.isControllerClass() }
+            if (controllerClassNames.isNotEmpty()) {
+                val phpIndex = PhpIndex.getInstance(fieldReference.project)
+                val containingClasses = phpIndex.getAllAncestorTypesFromFQNs(controllerClassNames)
+
+                val modelSubclasses = phpIndex.getAllModelSubclasses(settings)
+                completionResultSet.completeFromClasses(
+                    modelSubclasses,
+                    containingClasses = containingClasses
+                )
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/FetchTableCompletionContributor.kt
@@ -29,11 +29,12 @@ class FetchTableCompletionContributor : CompletionContributor() {
                     return false
                 }
                 val classRefType = methodReference.classReference?.type ?: return false
-                val phpIndex = PhpIndex.getInstance(methodReference.project)
                 val type = if (classRefType.isComplete)
                     classRefType
-                else
+                else {
+                    val phpIndex = PhpIndex.getInstance(methodReference.project)
                     phpIndex.completeType(methodReference.project, classRefType, null)
+                }
                 return type.types.contains("\\Cake\\ORM\\Locator\\LocatorInterface") ||
                         type.types.any { it.contains("Controller") }
             }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorCompletionContributor.kt
@@ -36,7 +36,7 @@ class TableLocatorCompletionContributor : CompletionContributor() {
                     phpIndex.completeType(methodReference.project, classRefType, null)
                 }
                 return type.types.contains("\\Cake\\ORM\\Locator\\LocatorInterface") ||
-                        type.types.any { it.contains("Controller") }
+                        type.types.any { it.isControllerClass() }
             }
         }
 

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorCompletionContributor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorCompletionContributor.kt
@@ -13,7 +13,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference
 import com.jetbrains.php.lang.psi.elements.ParameterList
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
 
-class FetchTableCompletionContributor : CompletionContributor() {
+class TableLocatorCompletionContributor : CompletionContributor() {
 
     init {
         val methodMatcher = object : PatternCondition<MethodReference>("LocatorInterfaceGetCondition") {

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorTypeProvider.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/model/TableLocatorTypeProvider.kt
@@ -52,7 +52,8 @@ class TableLocatorTypeProvider : PhpTypeProvider4 {
             val classReference = psiElement.classReference ?: return null
             for (type in classReference.type.types) {
                 if (type.hasGetTableLocatorMethodCall()) {
-                    val firstParam = psiElement.parameters.firstOrNull() as? StringLiteralExpression ?: return null
+                    val firstParam = psiElement.parameters.firstOrNull()
+                            as? StringLiteralExpression ?: return null
                     val contents = firstParam.contents
                     if (contents.length < 255) {
                         // sanity check

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,7 +44,7 @@
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerComponentCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.view.ViewHelperInViewCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.view.ViewHelperInViewHelperCompletionContributor" />
-        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.model.FetchTableCompletionContributor" />
+        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.model.TableLocatorCompletionContributor" />
 
         <gotoDeclarationHandler implementation="com.daveme.chocolateCakePHP.view.ElementGotoDeclarationHandler" />
         <gotoDeclarationHandler implementation="com.daveme.chocolateCakePHP.view.TemplateGotoDeclarationHandler" />

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,7 @@
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.controller.ControllerComponentCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.view.ViewHelperInViewCompletionContributor" />
         <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.view.ViewHelperInViewHelperCompletionContributor" />
+        <completion.contributor language="PHP" implementationClass="com.daveme.chocolateCakePHP.model.FetchTableCompletionContributor" />
 
         <gotoDeclarationHandler implementation="com.daveme.chocolateCakePHP.view.ElementGotoDeclarationHandler" />
         <gotoDeclarationHandler implementation="com.daveme.chocolateCakePHP.view.TemplateGotoDeclarationHandler" />

--- a/src/test/fixtures/cake3/vendor/cakephp.php
+++ b/src/test/fixtures/cake3/vendor/cakephp.php
@@ -33,9 +33,9 @@ namespace Cake\ORM {
     class Table {}
 
     class TableRegistry {
-    /**
-     * @return \Cake\ORM\Locator\LocatorInterface
-     */
+        /**
+         * @return \Cake\ORM\Locator\LocatorInterface
+         */
         public function getTableLocator() {}
     }
 }

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -185,4 +185,62 @@ class TableLocatorTest : BaseTestCase() {
         assertNotEmpty(result)
         assertTrue(result!!.contains("Articles"))
     }
+
+    fun `test TableRegistry static method argument can be autocompleted with quotes`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}result = TableRegistry::getTableLocator()->get('<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test TableRegistry static method argument can be autocompleted without quotes`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}result = TableRegistry::getTableLocator()->get(<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
 }

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -243,4 +243,122 @@ class TableLocatorTest : BaseTestCase() {
         assertNotEmpty(result)
         assertTrue(result!!.contains("Articles"))
     }
+
+    fun `test TableRegistry from getTableLocator method can be autocompleted with quotes and saved in a variable`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator();
+                ${'$'}result = ${'$'}locator->get('<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test TableRegistry from getTableLocator method can be autocompleted without quotes and saved in a variable`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator();
+                ${'$'}result = ${'$'}locator->get(<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test TableRegistry from getTableLocator method can be autocompleted with quotes inline`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator()->get('<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test TableRegistry from getTableLocator method can be autocompleted without quotes inline`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator()->get(<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
 }

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -128,7 +128,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
-    fun `test fetchTable argument can be autocompleted`() {
+    fun `test fetchTable argument can be autocompleted without quotes`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
             "cake3/src/Model/Table/ArticlesTable.php",
@@ -146,7 +146,36 @@ class TableLocatorTest : BaseTestCase() {
         class MovieController extends Controller
         {
             public function artist() {
-                ${'$'}result = ${'$'}this->fetchTable('<caret')
+                ${'$'}result = ${'$'}this->fetchTable(<caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test fetchTable argument can be autocompleted with quotes`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}result = ${'$'}this->fetchTable('<caret>
             }
         }
         """.trimIndent())

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -127,4 +127,33 @@ class TableLocatorTest : BaseTestCase() {
         assertNotEmpty(result)
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
+
+    fun `test fetchTable argument can be autocompleted`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}result = ${'$'}this->fetchTable('<caret')
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("Articles"))
+    }
 }

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -1,7 +1,10 @@
 package com.daveme.chocolateCakePHP.test
 
+import org.junit.Test
+
 class TableLocatorTest : BaseTestCase() {
 
+    @Test
     fun `test fetchTable returns methods from the users custom namespace in a controller`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -30,6 +33,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
+    @Test
     fun `test TableLocator get returns methods from the users custom namespace`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -64,6 +68,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
+    @Test
     fun `test TableLocator get returns methods from the users custom namespace when stored in a variable`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -99,6 +104,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
+    @Test
     fun `test static TableLocator get returns methods from the users custom namespace`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -128,6 +134,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
+    @Test
     fun `test fetchTable argument can be autocompleted without quotes`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -157,6 +164,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test fetchTable argument can be autocompleted with quotes`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -186,6 +194,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test TableRegistry static method argument can be autocompleted with quotes`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -215,6 +224,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test TableRegistry static method argument can be autocompleted without quotes`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -244,6 +254,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test TableRegistry from getTableLocator method can be autocompleted with quotes and saved in a variable`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -274,6 +285,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test TableRegistry from getTableLocator method can be autocompleted without quotes and saved in a variable`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -304,6 +316,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test types from TableRegistry from getTableLocator method can be determined when saved in a variable`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -334,6 +347,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 
+    @Test
     fun `test TableRegistry from getTableLocator method can be autocompleted with quotes inline`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -363,6 +377,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test TableRegistry from getTableLocator method can be autocompleted without quotes inline`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -392,6 +407,7 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    @Test
     fun `test types from getTableLocator method can be autocompleted when inline`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",

--- a/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
+++ b/src/test/kotlin/com/daveme/chocolateCakePHP/test/TableLocatorTest.kt
@@ -304,6 +304,36 @@ class TableLocatorTest : BaseTestCase() {
         assertTrue(result!!.contains("Articles"))
     }
 
+    fun `test types from TableRegistry from getTableLocator method can be determined when saved in a variable`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator();
+                ${'$'}result = ${'$'}locator->get('Articles')-><caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("myCustomArticleMethod"))
+    }
+
     fun `test TableRegistry from getTableLocator method can be autocompleted with quotes inline`() {
         myFixture.configureByFiles(
             "cake3/src/Controller/AppController.php",
@@ -360,5 +390,34 @@ class TableLocatorTest : BaseTestCase() {
         val result = myFixture.lookupElementStrings
         assertNotEmpty(result)
         assertTrue(result!!.contains("Articles"))
+    }
+
+    fun `test types from getTableLocator method can be autocompleted when inline`() {
+        myFixture.configureByFiles(
+            "cake3/src/Controller/AppController.php",
+            "cake3/src/Model/Table/ArticlesTable.php",
+            "cake3/vendor/cakephp.php"
+        )
+
+        myFixture.configureByText("MovieController.php", """
+        <?php
+
+        namespace App\Controller;
+
+        use Cake\Controller\Controller;
+        use Cake\ORM\TableRegistry;
+        
+        class MovieController extends Controller
+        {
+            public function artist() {
+                ${'$'}locator = ${'$'}this->getTableLocator()->get('Articles')-><caret>
+            }
+        }
+        """.trimIndent())
+
+        myFixture.completeBasic()
+        val result = myFixture.lookupElementStrings
+        assertNotEmpty(result)
+        assertTrue(result!!.contains("myCustomArticleMethod"))
     }
 }


### PR DESCRIPTION
- Add completion and type provider for `fetchTable` and `TableLocator->get()`
- Add InsertHandler so that the cursor is moved after the closing parenthesis ready for the user to type ';' (if assigning to a variable) or '->' (if writing the table locator inline)
- Resolves https://github.com/dmeybohm/chocolate-cakephp/issues/98