### PR TITLE
Change the default shortcut for toggling between controller/view

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -98,7 +98,10 @@
                 icon="com.daveme.chocolateCakePHP.cake.CakeIcons.LOGO_PNG"
                 description="Navigate to the corresponding controller for this view.">
             <add-to-group group-id="EditorContextBarMenu" anchor="first" />
-            <keyboard-shortcut first-keystroke="ctrl alt UP" keymap="$default" />
+
+            <keyboard-shortcut first-keystroke="ctrl alt shift HOME" keymap="$default" />
+            <keyboard-shortcut first-keystroke="control meta shift UP" keymap="Mac OS X" />
+            <keyboard-shortcut first-keystroke="control meta shift UP" keymap="Mac OS X 10.5+" />
         </action>
     </actions>
 


### PR DESCRIPTION
On Linux, the default shortcut key does not work.

Should probably use the RelatedItem interface instead, which can use the built-in "ctrl-alt-Home" / "shift-meta-up" shortcuts that go to related items.

But, that would require some major surgery. So not doing that at the moment.

So for now, change the shortcut key to match that related item pattern, but add the Shift key by default.