### PR TITLE
Add Settings.cake3AutoDetect property

### DIFF
--- a/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
+++ b/src/main/java/com/daveme/chocolateCakePHP/ConfigForm.java
@@ -37,7 +37,7 @@ class ConfigForm implements SearchableConfigurable {
 
     private void loadSettingsToUI(@NotNull Settings settings) {
         forceEnableCakePHP3CheckBox.setSelected(settings.getCake3ForceEnabled());
-        enableAutoDetectCake3CheckBox.setSelected(settings.getCake3Enabled());
+        enableAutoDetectCake3CheckBox.setSelected(settings.getCake3AutoDetect());
         updateCake3SettingsVisibility();
         appDirectoryTextField.setText(settings.getAppDirectory());
         appNamespaceTextField.setText(settings.getAppNamespace());
@@ -154,9 +154,11 @@ class ConfigForm implements SearchableConfigurable {
 
         // Ensure namespace starts with backslash:
         String namespace = appNamespaceTextField.getText();
-        if (settings.getCake3Enabled() &&
+        if (
+                settings.getCake3AutoDetect() &&
                 !namespace.isEmpty() &&
-                !namespace.startsWith("\\")) {
+                !namespace.startsWith("\\")
+        ) {
             String newNamespace = "\\" + namespace;
             appNamespaceTextField.setText(newNamespace);
         }

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
@@ -203,6 +203,7 @@ class Settings : PersistentStateComponent<SettingsState>, Disposable {
     val cake2Enabled get() = state.cake2Enabled
     val cake3Enabled get() = cake3ForceEnabled ||
             (state.cake3Enabled && autoDetectedValues.cake3OrLaterPresent)
+    val cake3AutoDetect get() = state.cake3Enabled
     val cake3ForceEnabled get() = state.cake3ForceEnabled
     var autoDetectedValues = CakeAutoDetectedValues()
 


### PR DESCRIPTION
In the settings form, we need to read / write the raw value of the cake3 autodetect value, which was formerly named cake3Enabled.

Since, we're using the cake3Enabled property in the Settings form now, that leads to a problem with settings the autodetected value to false when configuring Settings for new projects.

So, expose a new getter for the cake3AutoDetect, and set the state.cake3Enabled value from it.