### PR TITLE
Fix icon showing in inappropriate contexts

### DIFF
--- a/src/main/kotlin/com/daveme/chocolateCakePHP/view/ToggleBetweenControllerAndViewAction.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/view/ToggleBetweenControllerAndViewAction.kt
@@ -55,12 +55,16 @@ class ToggleBetweenControllerAndViewAction : AnAction() {
             return
         }
 
-        val psiFile = getPsiFile(project, e) ?: return
-        val isViewFile = isCakeViewFile(project, settings, psiFile)
-        val isControllerFile = isCakeControllerFile(psiFile)
+        val psiFile = getPsiFile(project, e)
+        if (psiFile == null) {
+            e.presentation.isEnabledAndVisible = false
+        } else {
+            val isViewFile = isCakeViewFile(project, settings, psiFile)
+            val isControllerFile = isCakeControllerFile(psiFile)
 
-        e.presentation.isEnabled = isViewFile || isControllerFile
-        e.presentation.isVisible = isViewFile
+            e.presentation.isEnabled = isViewFile || isControllerFile
+            e.presentation.isVisible = isViewFile
+        }
     }
 
     override fun actionPerformed(e: AnActionEvent) {


### PR DESCRIPTION
I think this is showing up even when file is null because we return, so let's set the EditorContextBarMenu hidden.

Resolves https://github.com/dmeybohm/chocolate-cakephp/issues/200