### PR TITLE
Cache UndefinedViewVariableInspectionSuppressor

### DIFF
--- a/src/main/kotlin/com/daveme/chocolateCakePHP/PhpFilesModificationTracker.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/PhpFilesModificationTracker.kt
@@ -1,0 +1,101 @@
+package com.daveme.chocolateCakePHP
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SimpleModificationTracker
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
+import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
+
+/**
+ * Tracks modifications to PHP files in the project.
+ *
+ * This is used to invalidate caches that depend on PHP file contents,
+ * such as the view variable cache which depends on controller files.
+ *
+ * The tracker uses lazy initialization - it only subscribes to VFS changes when
+ * first needed, and only if the plugin is enabled for the project. This ensures
+ * zero overhead for non-CakePHP projects.
+ */
+@Service(Service.Level.PROJECT)
+class PhpFilesModificationTracker(private val project: Project) : SimpleModificationTracker(), Disposable {
+
+    private val _isArmed: Boolean by lazy {
+        val settings = Settings.getInstance(project)
+        if (!settings.enabled) {
+            // Not a CakePHP project - don't arm
+            false
+        } else {
+            // CakePHP project detected - arm the VFS listener
+            val connection = project.messageBus.connect(this)
+            connection.subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
+                override fun after(events: List<VFileEvent>) {
+                    for (e in events) {
+                        if (affectsPhpFile(e)) {
+                            incModificationCount()
+                            break
+                        }
+                    }
+                }
+            })
+            true
+        }
+    }
+
+    /**
+     * Returns true if the tracker is armed and actively tracking PHP file changes.
+     * Returns false if the plugin is not enabled for this project.
+     */
+    val isArmed: Boolean
+        get() = _isArmed
+
+    /**
+     * Ensures the tracker is armed if this is a CakePHP project.
+     * This triggers lazy initialization which checks settings.enabled and
+     * subscribes to VFS changes if appropriate. Safe to call multiple times.
+     */
+    fun ensureArmed() {
+        // Access the property to trigger lazy initialization
+        _isArmed
+    }
+
+    private fun affectsPhpFile(e: VFileEvent): Boolean {
+        // Handle create/delete by path
+        when (e) {
+            is VFileCreateEvent, is VFileDeleteEvent -> {
+                return e.path.endsWith(".php")
+            }
+        }
+
+        // For events with a file object (content change, rename, move)
+        val file = when (e) {
+            is VFileContentChangeEvent -> e.file
+            is VFilePropertyChangeEvent -> e.file
+            is VFileMoveEvent -> e.file
+            else -> null
+        } ?: return false
+
+        // Check if the file is a PHP file
+        if (file.extension == "php") {
+            return true
+        }
+
+        // Also handle rename where the file becomes a PHP file
+        if (e is VFilePropertyChangeEvent && e.isRename) {
+            val newName = e.newValue as? String ?: return false
+            return newName.endsWith(".php")
+        }
+
+        return false
+    }
+
+    override fun dispose() {
+        // Connection is automatically disposed via parent disposable
+    }
+}

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/view/UndefinedViewVariableInspectionSuppressor.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/view/UndefinedViewVariableInspectionSuppressor.kt
@@ -1,8 +1,10 @@
 package com.daveme.chocolateCakePHP.view
 
+import com.daveme.chocolateCakePHP.PhpFilesModificationTracker
 import com.daveme.chocolateCakePHP.Settings
 import com.daveme.chocolateCakePHP.cake.templatesDirectoryOfViewFile
 import com.daveme.chocolateCakePHP.view.viewfileindex.ViewFileIndexService
+import com.daveme.chocolateCakePHP.view.viewvariableindex.ViewVariableCache
 import com.daveme.chocolateCakePHP.view.viewvariableindex.ViewVariableIndexService
 import com.intellij.codeInspection.InspectionSuppressor
 import com.intellij.codeInspection.SuppressQuickFix
@@ -38,13 +40,30 @@ class UndefinedViewVariableInspectionSuppressor : InspectionSuppressor {
 
         try {
             val filenameKey = ViewFileIndexService.canonicalizeFilenameToKey(templatesDir, settings, relativePath)
-            val resultType = ViewVariableIndexService.lookupVariableTypeFromViewPathInSmartReadAction(
-                project,
-                settings,
+
+            // Use cache for variable lookup
+            val cache = project.getService(ViewVariableCache::class.java)
+            val phpTracker = project.getService(PhpFilesModificationTracker::class.java)
+
+            // Arm the tracker now that we know this is a CakePHP project
+            // This is done lazily to avoid overhead in non-CakePHP projects
+            phpTracker.ensureArmed()
+
+            return cache.isVariableDefined(
+                psiFile,
                 filenameKey,
-                variable.name
-            )
-            return resultType.types.size > 0
+                variable.name,
+                phpTracker
+            ) { key, varName ->
+                // Lookup function called only on cache miss
+                val resultType = ViewVariableIndexService.lookupVariableTypeFromViewPathInSmartReadAction(
+                    project,
+                    settings,
+                    key,
+                    varName
+                )
+                resultType.types.size > 0
+            }
         } catch (e: Exception) {
             println("Exception: ${e.message}")
             return false

--- a/src/main/kotlin/com/daveme/chocolateCakePHP/view/viewvariableindex/ViewVariableCache.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/view/viewvariableindex/ViewVariableCache.kt
@@ -1,0 +1,87 @@
+package com.daveme.chocolateCakePHP.view.viewvariableindex
+
+import com.daveme.chocolateCakePHP.PhpFilesModificationTracker
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+
+/**
+ * Cache for view variable existence checks.
+ *
+ * This cache stores boolean results indicating whether a variable is defined
+ * for a given view file. The cache is automatically invalidated when:
+ * - The view file itself changes
+ * - Any PHP file in the project changes (via PhpFilesModificationTracker)
+ *
+ * If the PhpFilesModificationTracker is not armed (project is not a CakePHP project),
+ * the cache bypasses itself and performs direct lookups to avoid stale data.
+ */
+@Service(Service.Level.PROJECT)
+class ViewVariableCache(private val project: Project) {
+
+    companion object {
+        private val VARIABLE_CACHE_KEY = Key.create<CachedValue<MutableMap<String, Boolean>>>("CHOCOLATE_CAKEPHP_VIEW_VARIABLE_CACHE")
+    }
+
+    /**
+     * Checks if a variable is defined for the given view file.
+     *
+     * If the phpTracker is not armed (not a CakePHP project), bypasses caching
+     * and performs a direct lookup to avoid returning stale data.
+     *
+     * @param psiFile The view file to check
+     * @param filenameKey The canonical filename key for the view
+     * @param variableName The name of the variable to check
+     * @param phpTracker Modification tracker for PHP files
+     * @param lookupFn Function to perform the actual lookup if not cached
+     * @return true if the variable is defined, false otherwise
+     */
+    fun isVariableDefined(
+        psiFile: PsiFile,
+        filenameKey: String,
+        variableName: String,
+        phpTracker: ModificationTracker,
+        lookupFn: (String, String) -> Boolean
+    ): Boolean {
+        // Check if the tracker is actually armed
+        // If tracker is null or not armed, bypass caching and do direct lookup
+        val tracker = phpTracker as? PhpFilesModificationTracker
+        if (tracker == null || !tracker.isArmed) {
+            // Not a CakePHP project or invalid tracker - don't use cache, just do direct lookup
+            return lookupFn(filenameKey, variableName)
+        }
+
+        val cachedValuesManager = CachedValuesManager.getManager(project)
+
+        // Get or create the cache for this file
+        val variableCache = cachedValuesManager.getCachedValue(
+            psiFile,
+            VARIABLE_CACHE_KEY,
+            {
+                CachedValueProvider.Result.create(
+                    mutableMapOf<String, Boolean>(),
+                    psiFile,  // Invalidate when the view file changes
+                    phpTracker  // Invalidate when any PHP file changes
+                )
+            },
+            false
+        )
+
+        // Create a cache key for this specific variable lookup
+        val cacheKey = "$filenameKey::$variableName"
+
+        // Return cached value if present, otherwise compute and cache
+        if (variableCache.containsKey(cacheKey)) {
+            return variableCache[cacheKey]!!
+        }
+
+        val result = lookupFn(filenameKey, variableName)
+        variableCache[cacheKey] = result
+        return result
+    }
+}


### PR DESCRIPTION
- Add ViewVariableCache for caching undefined variable suppression, which can be intensive
- Add PhpFilesModificationTracker to invalidate the cache whenever a php file changes.