### PR TITLE
Fix inaccurate compare of Settings when in autodetect mode

### DIFF
--- a/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
+++ b/src/main/kotlin/com/daveme/chocolateCakePHP/Settings.kt
@@ -206,10 +206,11 @@ class Settings(val project: Project) : PersistentStateComponent<SettingsState>, 
     }
 
     val appNamespace get(): String {
-        return if (state.cake3Enabled && !state.cake3ForceEnabled)
+        val namespace = if (state.cake3Enabled && !state.cake3ForceEnabled)
             getAutoDetectedValues().namespace
         else
-            return state.appNamespace.absoluteClassName()
+            state.appNamespace
+        return namespace.absoluteClassName()
     }
 
     val cake2AppDirectory get() = state.cake2AppDirectory


### PR DESCRIPTION
Fix inaccurate comparison of Settings object from GUI serialization by always absolutizing the class name.

Resolves https://github.com/dmeybohm/chocolate-cakephp/issues/232