### PR TITLE
Remove listProductsRelease command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,6 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
-
       # Run tests
       - name: Run Tests
         run: ./gradlew check


### PR DESCRIPTION
We aren't running the pluginVerifier in CI, so remove the listProductsReleases which takes a while.